### PR TITLE
Make everything more verbose, maintain packages within GitHub using LFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+> [!WARNING]
+> This fork has been modified to not use Project IDs and Private tokens that download from gitlab unlike the original mobox.
+>
+> Instead, all the base packages, wine packages and
+> the package manager itself are taken from this repo's releases by the installer script. The installer and the package-manager have also been modified to be more verbose
+> about what they are doing in the background.
+> 
+> The instructions, usage and everything else remains exactly the same.
+
+# README
 ![logo](docs/img/logo.png "logo")
 
 English

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ English
 2. Open termux and paste command
 
 ```bash
-curl -o ~/x https://raw.githubusercontent.com/olegos2/mobox/main/install && . ~/x
+curl -o ~/x https://raw.githubusercontent.com/EDLLT/mobox/main/install && . ~/x
 ```
 
 3. Type `mobox` in termux.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 > This fork has been modified to not use Project IDs and Private tokens that download from gitlab unlike the original mobox.
 >
 > Instead, all the base packages, wine packages and
-> the package manager itself are taken from this repo's releases by the installer script. The installer and the package-manager have also been modified to be more verbose
-> about what they are doing in the background.
+> the package manager itself are taken from [this repo](https://github.com/EDLLT/mobox_packages) by the installer script. The installer and the package-manager have also been modified to be more verbose
+> about what they are doing in the background. UNLESS you use the non-wow64 version in which case it will default to using olegos2's gitlab project/token approach
+>
 > 
 > The instructions, usage and everything else remains exactly the same.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ English
 2. Open termux and paste command
 
 ```bash
-curl -s -o ~/x https://raw.githubusercontent.com/olegos2/mobox/main/install && . ~/x
+curl -o ~/x https://raw.githubusercontent.com/olegos2/mobox/main/install && . ~/x
 ```
 
 3. Type `mobox` in termux.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 >
 > 
 > The instructions, usage and everything else remains exactly the same.
+> I had great ambitions for this project; however, I unfortunately don't have time and great alternatives to mobox exist.
 
 # README
 ![logo](docs/img/logo.png "logo")

--- a/install
+++ b/install
@@ -69,10 +69,12 @@ esac
 echo "Installing mobox"
 
 # Download ESSENTIAL files from gitlab(hidden behind a project id and private token)
-function wget-git-q {
-    wget --show-progress --retry-connrefused --tries=0 --header "PRIVATE-TOKEN: $PRIVATE_TOKEN" "https://gitlab.com/api/v4/projects/$PROJECT_ID/repository/files/$1/raw?ref=main" -O $2
-    return $?
-}
+
+# Redundant as we're not downloading anything, instead we let package-manager handle it
+# function wget-git-q {
+#     wget --show-progress --retry-connrefused --tries=0 --header "PRIVATE-TOKEN: $PRIVATE_TOKEN" "https://gitlab.com/api/v4/projects/$PROJECT_ID/repository/files/$1/raw?ref=main" -O $2
+#     return $?
+# }
 
 echo "Updating package manager"
 
@@ -100,7 +102,7 @@ fi
 # fi
 
 # Use our repo's package manager
-curl -o "$PREFIX/glibc/opt/package-manager/package-manager" https://raw.githubusercontent.com/EDLLT/mobox/main/package-manager
+curl https://raw.githubusercontent.com/EDLLT/mobox/main/package-manager -o "$PREFIX/glibc/opt/package-manager/package-manager"
 
 # Executes the package manager script which sets up everything mobox related
 . $PREFIX/glibc/opt/package-manager/package-manager

--- a/install
+++ b/install
@@ -3,9 +3,9 @@
 rm ~/x
 
 echo "Installing termux-am"
-pkg install termux-am -y &>/dev/null
+pkg install termux-am -y
 
-termux-setup-storage & sleep 4 &>/dev/null
+termux-setup-storage & sleep 4
 
 while true; do
     if [ -d ~/storage/shared ]; then
@@ -16,23 +16,25 @@ while true; do
     sleep 3
 done
 
+# Clean and install all required dependencies
 echo "Installing termux packages"
 apt-get clean
-apt-get update >/dev/null 2>&1
-apt-get -y --with-new-pkgs -o Dpkg::Options::="--force-confdef" upgrade >/dev/null 2>&1
-pkg install x11-repo -y &>/dev/null
-pkg install pulseaudio -y &>/dev/null
-pkg install xwayland -y &>/dev/null
-pkg install wget -y &>/dev/null
-pkg install tsu -y &>/dev/null
-pkg install root-repo -y &>/dev/null
-pkg install patchelf -y &>/dev/null
-pkg install p7zip -y &>/dev/null
-pkg install xorg-xrandr -y &>/dev/null
-pkg install ncurses-utils -y &>/dev/null
-pkg install hashdeep -y &>/dev/null
-pkg install termux-x11-nightly -y &>/dev/null
+apt-get update >/dev/null
+apt-get -y --with-new-pkgs -o Dpkg::Options::="--force-confdef" upgrade >/dev/null
+pkg install x11-repo -y
+pkg install pulseaudio -y
+pkg install xwayland -y
+pkg install wget -y
+pkg install tsu -y
+pkg install root-repo -y
+pkg install patchelf -y
+pkg install p7zip -y
+pkg install xorg-xrandr -y
+pkg install ncurses-utils -y
+pkg install hashdeep -y
+pkg install termux-x11-nightly -y
 
+# Remove previous glibc
 if [ -e $PREFIX/glibc ]; then
     echo -n "Removing previous glibc. Continue? (Y/n) "
     read i
@@ -43,6 +45,7 @@ if [ -e $PREFIX/glibc ]; then
     fi
 fi
 
+# Select new wow64 wine or wine-ge
 INSTALL_WOW64=0
 
 echo "Select an option"
@@ -65,14 +68,18 @@ esac
 
 echo "Installing mobox"
 
+# Download ESSENTIAL files from gitlab(hidden behind a project id and private token)
 function wget-git-q {
-    wget -q --retry-connrefused --tries=0 --header "PRIVATE-TOKEN: $PRIVATE_TOKEN" "https://gitlab.com/api/v4/projects/$PROJECT_ID/repository/files/$1/raw?ref=main" -O $2
+    wget --show-progress --retry-connrefused --tries=0 --header "PRIVATE-TOKEN: $PRIVATE_TOKEN" "https://gitlab.com/api/v4/projects/$PROJECT_ID/repository/files/$1/raw?ref=main" -O $2
     return $?
 }
 
 echo "Updating package manager"
+
+# Create the following directory(It doesn't exist since we'd removed glibc earlier)
 mkdir -p $PREFIX/glibc/opt/package-manager/installed
 
+# depending on what we selected earlier, set the private token and project id
 if [ "$INSTALL_WOW64" = "1" ]; then
 echo "PRIVATE_TOKEN=glpat-h5r7HjKoPKZPxmfg79xs
 PROJECT_ID=54240888">$PREFIX/glibc/opt/package-manager/token
@@ -81,19 +88,34 @@ echo "PRIVATE_TOKEN=glpat-Xs4HfrCkMpbedkPycqzP
 PROJECT_ID=52465323">$PREFIX/glibc/opt/package-manager/token
 fi
 
+# Loads up our private token and project id into our current shell session
 . $PREFIX/glibc/opt/package-manager/token
-if ! wget-git-q "package-manager" "$PREFIX/glibc/opt/package-manager/package-manager"; then
-    echo "Download failed"
-    return 1
-fi
+
+# Downloads the package-manager script
+
+# {COMMENTED OUT! We want to use the package manager that we have instead}
+# if ! wget-git-q "package-manager" "$PREFIX/glibc/opt/package-manager/package-manager"; then
+#     echo "Download failed"
+#     return 1
+# fi
+
+# Use this repo's package manager
+cp package-manager "$PREFIX/glibc/opt/package-manager/package-manager"
+
+# Executes the package manager script which sets up everything mobox related
 . $PREFIX/glibc/opt/package-manager/package-manager
+
+# This is what installs everything mobox needs(base packages and wine?*)
 sync-all
 
+
+# Installs wine
 if [ "$INSTALL_WOW64" = "1" ]; then
 sync-package wine-9.3-vanilla-wow64
 else
 sync-package wine-ge-custom-8-25
 fi
 
+# Create a symlink for mobox
 ln -sf $PREFIX/glibc/opt/scripts/mobox $PREFIX/bin/mobox
 echo "To start - type \"mobox\""

--- a/install
+++ b/install
@@ -99,8 +99,8 @@ fi
 #     return 1
 # fi
 
-# Use this repo's package manager
-cp package-manager "$PREFIX/glibc/opt/package-manager/package-manager"
+# Use our repo's package manager
+curl -o "$PREFIX/glibc/opt/package-manager/package-manager" https://raw.githubusercontent.com/EDLLT/mobox/main/package-manager
 
 # Executes the package manager script which sets up everything mobox related
 . $PREFIX/glibc/opt/package-manager/package-manager

--- a/install
+++ b/install
@@ -83,11 +83,11 @@ mkdir -p $PREFIX/glibc/opt/package-manager/installed
 
 # depending on what we selected earlier, set the private token and project id
 if [ "$INSTALL_WOW64" = "1" ]; then
-echo "PRIVATE_TOKEN=glpat-h5r7HjKoPKZPxmfg79xs
-PROJECT_ID=54240888">$PREFIX/glibc/opt/package-manager/token
+    echo "PRIVATE_TOKEN=glpat-h5r7HjKoPKZPxmfg79xs
+    PROJECT_ID=54240888">$PREFIX/glibc/opt/package-manager/token
 else
-echo "PRIVATE_TOKEN=glpat-Xs4HfrCkMpbedkPycqzP
-PROJECT_ID=52465323">$PREFIX/glibc/opt/package-manager/token
+    echo "PRIVATE_TOKEN=glpat-Xs4HfrCkMpbedkPycqzP
+    PROJECT_ID=52465323">$PREFIX/glibc/opt/package-manager/token
 fi
 
 # Loads up our private token and project id into our current shell session
@@ -95,14 +95,15 @@ fi
 
 # Downloads the package-manager script
 
-# {COMMENTED OUT! We want to use the package manager that we have instead}
-# if ! wget-git-q "package-manager" "$PREFIX/glibc/opt/package-manager/package-manager"; then
-#     echo "Download failed"
-#     return 1
-# fi
-
-# Use our repo's package manager
-curl https://raw.githubusercontent.com/EDLLT/mobox/main/package-manager -o "$PREFIX/glibc/opt/package-manager/package-manager"
+# Use our repo's package manager only if wow64 is selected(As I haven't uploaded the non-wow64 versions to github)
+if [ "$INSTALL_WOW64" = "1" ]; then
+    curl https://raw.githubusercontent.com/EDLLT/mobox/main/package-manager -o "$PREFIX/glibc/opt/package-manager/package-manager"
+else
+    if ! wget-git-q "package-manager" "$PREFIX/glibc/opt/package-manager/package-manager"; then
+        echo "Download failed"
+        return 1
+    fi
+fi
 
 # Executes the package manager script which sets up everything mobox related
 . $PREFIX/glibc/opt/package-manager/package-manager

--- a/install
+++ b/install
@@ -81,7 +81,7 @@ echo "Updating package manager"
 # Create the following directory(It doesn't exist since we'd removed glibc earlier)
 mkdir -p $PREFIX/glibc/opt/package-manager/installed
 
-# depending on what we selected earlier, set the private token and project id
+# Depending on what we selected earlier, set the private token and project id
 if [ "$INSTALL_WOW64" = "1" ]; then
     echo "PRIVATE_TOKEN=glpat-h5r7HjKoPKZPxmfg79xs
     PROJECT_ID=54240888">$PREFIX/glibc/opt/package-manager/token

--- a/install
+++ b/install
@@ -114,9 +114,9 @@ sync-all
 
 # Installs wine
 if [ "$INSTALL_WOW64" = "1" ]; then
-sync-package wine-9.3-vanilla-wow64
+    sync-package wine-9.3-vanilla-wow64
 else
-sync-package wine-ge-custom-8-25
+    sync-package wine-ge-custom-8-25
 fi
 
 # Create a symlink for mobox

--- a/package-manager
+++ b/package-manager
@@ -55,7 +55,8 @@ declare -a outdated_packages=(\
 )
 
 function wget-git {
-	wget --show-progress --timeout=6 --retry-connrefused --tries=0 --header "PRIVATE-TOKEN: $PRIVATE_TOKEN" "https://gitlab.com/api/v4/projects/$PROJECT_ID/repository/files/$1/raw?ref=main" -O $2
+	#wget --show-progress --timeout=6 --retry-connrefused --tries=0 --header "PRIVATE-TOKEN: $PRIVATE_TOKEN" "https://gitlab.com/api/v4/projects/$PROJECT_ID/repository/files/$1/raw?ref=main" -O $2
+	wget --show-progress --timeout=6 --retry-connrefused --tries=0 "https://github.com/EDLLT/mobox_packages/raw/master/$1?download=" -O $2
 	return $?
 }
 

--- a/package-manager
+++ b/package-manager
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# TODO: Look for sync-all function
-
 # Loads up our token for downloading from gitlab
 . $PREFIX/glibc/opt/package-manager/token
 
@@ -49,7 +47,7 @@ declare -a wine_packages=(\
 	wine-9.3-vanilla-wow64 \
 )
 
-# ?
+# A list of outdated packages
 declare -a outdated_packages=(\
 	d3d \
 	mesa \

--- a/package-manager
+++ b/package-manager
@@ -60,7 +60,7 @@ function wget-git {
 }
 
 function wget-git-q {
-	wget --show-progress --timeout=6 --retry-connrefused --tries=0 --header "PRIVATE-TOKEN: $PRIVATE_TOKEN" "https://gitlab.com/api/v4/projects/$PROJECT_ID/repository/files/$1/raw?ref=main" -O $2
+	wget-git "$@"
 	return $?
 }
 

--- a/package-manager
+++ b/package-manager
@@ -5,22 +5,22 @@
 
 # A dictionary in bash containing latest* versions of packages
 declare -A packages_list=(
-	      [box64-binaries]=10
-	                [dxvk]=2
-	        [glibc-prefix]=2
-	         [prefix-apps]=2
-	             [scripts]=27
-	              [turnip]=8
-	          [virgl-mesa]=1
-	             [wined3d]=1
-  [wine-9.0-staging-wow64]=1
- [wine-8.18-staging-wow64]=1
- [wine-8.18-vanilla-wow64]=1
-  [wine-9.1-vanilla-wow64]=2
-  [wine-9.2-vanilla-wow64]=1
-  [wine-9.3-vanilla-wow64]=1
-                 [libudev]=1
-            [en-ru-locale]=1
+	[box64-binaries]=10
+	[dxvk]=2
+	[glibc-prefix]=2
+	[prefix-apps]=2
+	[scripts]=27
+	[turnip]=8
+	[virgl-mesa]=1
+	[wined3d]=1
+	[wine-9.0-staging-wow64]=1
+	[wine-8.18-staging-wow64]=1
+	[wine-8.18-vanilla-wow64]=1
+	[wine-9.1-vanilla-wow64]=2
+	[wine-9.2-vanilla-wow64]=1
+	[wine-9.3-vanilla-wow64]=1
+	[libudev]=1
+	[en-ru-locale]=1
 )
 
 # A list in bash containing names of base_packages which are installed during sync_all*

--- a/package-manager
+++ b/package-manager
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+# TODO: Look for sync-all function
+
+# Loads up our token for downloading from gitlab
+. $PREFIX/glibc/opt/package-manager/token
+
+# A dictionary in bash containing latest* versions of packages
+declare -A packages_list=(
+	      [box64-binaries]=10
+	                [dxvk]=2
+	        [glibc-prefix]=2
+	         [prefix-apps]=2
+	             [scripts]=27
+	              [turnip]=8
+	          [virgl-mesa]=1
+	             [wined3d]=1
+  [wine-9.0-staging-wow64]=1
+ [wine-8.18-staging-wow64]=1
+ [wine-8.18-vanilla-wow64]=1
+  [wine-9.1-vanilla-wow64]=2
+  [wine-9.2-vanilla-wow64]=1
+  [wine-9.3-vanilla-wow64]=1
+                 [libudev]=1
+            [en-ru-locale]=1
+)
+
+# A list in bash containing names of base_packages which are installed during sync_all*
+declare -a base_packages=(\
+	box64-binaries \
+	dxvk \
+	glibc-prefix \
+	prefix-apps \
+	scripts \
+	turnip \
+	virgl-mesa \
+	wined3d \
+	libudev \
+	en-ru-locale \
+)
+
+# A list of available wine packages to download for mobox
+declare -a wine_packages=(\
+	wine-9.0-staging-wow64 \
+	wine-8.18-staging-wow64 \
+	wine-8.18-vanilla-wow64 \
+	wine-9.1-vanilla-wow64 \
+	wine-9.2-vanilla-wow64 \
+	wine-9.3-vanilla-wow64 \
+)
+
+# ?
+declare -a outdated_packages=(\
+	d3d \
+	mesa \
+	wine-ge-custom-8-25 \
+)
+
+function wget-git {
+	wget --show-progress --timeout=6 --retry-connrefused --tries=0 --header "PRIVATE-TOKEN: $PRIVATE_TOKEN" "https://gitlab.com/api/v4/projects/$PROJECT_ID/repository/files/$1/raw?ref=main" -O $2
+	return $?
+}
+
+function wget-git-q {
+	wget --show-progress --timeout=6 --retry-connrefused --tries=0 --header "PRIVATE-TOKEN: $PRIVATE_TOKEN" "https://gitlab.com/api/v4/projects/$PROJECT_ID/repository/files/$1/raw?ref=main" -O $2
+	return $?
+}
+
+function remove-package {
+	if [ -e "$PREFIX/glibc/opt/package-manager/installed/$1" ] && [ -s "$PREFIX/glibc/opt/package-manager/installed/$1_lists" ]; then
+		echo "Removing $1"
+		while read i; do
+			rm -rf "$PREFIX/$i"
+		done < "$PREFIX/glibc/opt/package-manager/installed/$1_lists"
+		rm -rf "$PREFIX/glibc/opt/package-manager/installed/$1"
+		rm -rf "$PREFIX/glibc/opt/package-manager/installed/$1_lists"
+		rm -rf "$PREFIX/glibc/opt/package-manager/installed/$1_md5"
+		if [[ ${wine_packages[@]} =~ $1 ]]; then
+			echo "Removing $1 prefix"
+			rm -rf "$PREFIX/glibc/$1"
+		fi
+	fi
+}
+
+function sync-package {
+	# Check the current version of the package to be installed if it exists
+	if [ -e "$PREFIX/glibc/opt/package-manager/installed/$1" ]; then
+		local_version=$(cat "$PREFIX/glibc/opt/package-manager/installed/$1")
+	else
+		local_version=0
+	fi
+
+	# Check the dictionary of latest package versions available
+	version=${packages_list[$1]}
+	
+	# If the package list's version is greater than the one locally installed then install the package
+	if ((version > local_version)); then
+		
+		mkdir -p $PREFIX/glibc/opt/package-manager/temp
+		wget-git "$1.tar.xz" "$PREFIX/glibc/opt/package-manager/temp/$1.tar.xz"
+		if [ "$?" = "0" ]; then
+			# Remove a folder with the name of the package we're trying to install if it exists
+			rm -rf "$PREFIX/glibc/opt/package-manager/temp/$1"
+			
+			# Create a folder with the name of the package we're trying to install
+			mkdir -p "$PREFIX/glibc/opt/package-manager/temp/$1"
+
+			# Extract our tar to the newly created folder
+			tar -xf "$PREFIX/glibc/opt/package-manager/temp/$1.tar.xz" -C "$PREFIX/glibc/opt/package-manager/temp/$1"
+
+			# Uninstall the package if it was previously installed before attempting to install the new one
+			remove-package $1
+
+
+			echo "Updating $1"
+
+			# This is how the package manager tracks the packages installed
+			find "$PREFIX/glibc/opt/package-manager/temp/$1" -type f | sed "s|^/data/data/com.termux/files/usr/glibc/opt/package-manager/temp/$1/||">"$PREFIX/glibc/opt/package-manager/installed/$1_lists"
+			md5deep -sr "$PREFIX/glibc/opt/package-manager/temp/$1" | sed "s| /data/data/com.termux/files/usr/glibc/opt/package-manager/temp/$1/| |">"$PREFIX/glibc/opt/package-manager/installed/$1_md5"
+			
+			# Yes, every single package installed has a glibc directory inside it
+			# We are now extracting them all to the prefix
+			cp -rf "$PREFIX/glibc/opt/package-manager/temp/$1/glibc" $PREFIX
+			echo "$version">"$PREFIX/glibc/opt/package-manager/installed/$1"
+		else
+			echo "Couldn't update $1: download failed"
+			rm "$PREFIX/glibc/opt/package-manager/temp/$1.tar.xz"
+			rm -rf "$PREFIX/glibc/opt/package-manager/temp/$1"
+			return 1
+		fi
+
+		# Delete the tar file and folder we created
+		rm "$PREFIX/glibc/opt/package-manager/temp/$1.tar.xz"
+		rm -rf "$PREFIX/glibc/opt/package-manager/temp/$1"
+	fi
+	return 0
+}
+
+function validate-package {
+	echo "Checking md5 for $1"
+	if [ ! -e "$PREFIX/glibc/opt/package-manager/installed/$1_md5" ]; then
+		echo "$1 md5 not found"
+		return 1
+	fi
+	cd $PREFIX
+	md5sum -c "$PREFIX/glibc/opt/package-manager/installed/$1_md5"
+	if [ "$?" = "0" ]; then
+		cd
+		echo "OK"
+	else
+		cd
+		echo "Mismatch"
+		rm -rf "$PREFIX/glibc/opt/package-manager/installed/$1"
+		sync-package $1
+	fi
+}
+
+
+function sync-all {
+	echo "Syncing packages"
+	mkdir -p $PREFIX/glibc/opt/package-manager/installed
+
+	# Remove outdated packages
+	for i in "${outdated_packages[@]}"; do
+		remove-package $i
+	done
+
+	# Download every package from the base_packages list
+	for i in "${base_packages[@]}"; do
+		sync-package $i
+	done
+
+	# Download all the wine packages from the wine_packages list
+	for i in "${wine_packages[@]}"; do
+		if [ -e "$PREFIX/glibc/opt/package-manager/installed/$i" ]; then
+			sync-package $i
+		fi
+	done
+}
+
+function validate-all {
+	echo "Validating packages"
+	mkdir -p $PREFIX/glibc/opt/package-manager/installed
+	for i in "${base_packages[@]}"; do
+		validate-package $i
+	done
+	for i in "${wine_packages[@]}"; do
+		if [ -e "$PREFIX/glibc/opt/package-manager/installed/$i" ]; then
+			validate-package $i
+		fi
+	done
+}


### PR DESCRIPTION
I don't expect this to get merged; however, I believe the upstream project should instead become like this and be more clear about what it's doing in the background, where it's getting the files from and allow people to see all the files being downloaded to easily download it for themselves if they desired.

I'd be happy to edit my commits to instead make it based off of your repo(you can fork mobox_packages and use git lfs).
This will also allow people to contribute more easily to mobox.